### PR TITLE
Fix for the issue with scoring and some minor optimizations and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
-# Browser Capabilities GoLang Project
+Golang CLient for Browser Capabilities Project
+==============================================
 
-PHP has `get_browser()` function which tells what the user's browser is capable of.
-You can check original documentation [here](http://php.net/get_browser). 
-This is GoLang analog of `get_browser()` function.
+[Browscap](http://browscap.org/) provides regularly updated rules for parsing user agents.
 
-[![Build Status](https://secure.travis-ci.org/digitalcrab/browscap_go.png?branch=master)](http://travis-ci.org/digitalcrab/browscap_go)
+For more info check the [officall PHP client](https://github.com/browscap/browscap-php).
 
-## Introduction
-
-The [browscap.ini](http://browscap.org/) file is a database which provides a lot of details about 
-browsers and their capabilities, such as name, versions, Javascript support and so on.
-
-## Quick start
-
-First of all you need initialize library with [browscap.ini](http://browscap.org/) file. 
-And then you can get Browser information as `Browser` structure.
+Example:
+--------
 
 ```go
 import (
@@ -38,6 +30,45 @@ func main() {
     	fmt.Printf("IsMobile = %t\n", browser.IsMobile())
 	}
 }
+```
+
+Browser object fields
+---------------------
+
+```go
+Browser         string
+BrowserVersion  string
+BrowserMajorVer string
+BrowserMinorVer string
+// Browser, Application, Bot/Crawler, Useragent Anonymizer, Offline Browser,
+// Multimedia Player, Library, Feed Reader, Email Client or unknown
+BrowserType string
+
+Platform        string
+PlatformShort   string
+PlatformVersion string
+
+// Mobile Phone, Mobile Device, Tablet, Desktop, TV Device, Console,
+// FonePad, Ebook Reader, Car Entertainment System or unknown
+DeviceType  string
+DeviceName  string
+DeviceBrand string
+
+Crawler string
+
+Cookies    string
+JavaScript string
+
+RenderingEngineName    string
+RenderingEngineVersion string
+```
+
+Bechmark
+--------
+
+```
+BenchmarkInit-4         	       1	2256895168 ns/op	346136904 B/op	 5700912 allocs/op
+BenchmarkGetBrowser-4   	   10000	    140975 ns/op	      37 B/op	       1 allocs/op
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Golang CLient for Browser Capabilities Project
+Golang Client for Browser Capabilities Project
 ==============================================
 
 [Browscap](http://browscap.org/) provides regularly updated rules for parsing user agents.

--- a/backward_compatibility.go
+++ b/backward_compatibility.go
@@ -1,0 +1,34 @@
+package browscap_go
+
+import "fmt"
+
+var backwardCompatibleBrowsCap *BrowsCap
+
+// Deprecated: Use NewBrowsCapFromFile
+func InitBrowsCap(path string, force bool) error {
+	if backwardCompatibleBrowsCap != nil && !force {
+		return nil
+	}
+	var err error
+
+	// Load ini file
+	if backwardCompatibleBrowsCap, err = NewBrowsCapFromFile(path); err != nil {
+		return fmt.Errorf("browscap: An error occurred while reading file, %v ", err)
+	}
+
+	return nil
+}
+
+// Deprecated: Use BrowsCap.InitializedVersion
+func InitializedVersion() string {
+	return backwardCompatibleBrowsCap.InitializedVersion()
+}
+
+// Deprecated: Use BrowsCap.GetBrowser
+func GetBrowser(userAgent string) (browser *Browser, ok bool) {
+	if backwardCompatibleBrowsCap == nil {
+		return
+	}
+
+	return backwardCompatibleBrowsCap.GetBrowser(userAgent)
+}

--- a/browscap.go
+++ b/browscap.go
@@ -17,12 +17,7 @@ var (
 	dict        *dictionary
 	initialized bool
 	version     string
-	debug       bool
 )
-
-func Debug(val bool) {
-	debug = val
-}
 
 func InitBrowsCap(path string, force bool) error {
 	if initialized && !force {

--- a/browscap.go
+++ b/browscap.go
@@ -16,29 +16,13 @@ const (
 	CheckVersionUrl = "http://browscap.org/version-number"
 )
 
-var (
-	dict        *dictionary
-	initialized bool
-	version     string
-)
-
-func InitBrowsCap(path string, force bool) error {
-	if initialized && !force {
-		return nil
-	}
-	var err error
-
-	// Load ini file
-	if dict, err = loadFromIniFile(path); err != nil {
-		return fmt.Errorf("browscap: An error occurred while reading file, %v ", err)
-	}
-
-	initialized = true
-	return nil
+type BrowsCap struct {
+	dict    *dictionary
+	version string
 }
 
-func InitializedVersion() string {
-	return version
+func (browscap *BrowsCap) InitializedVersion() string {
+	return browscap.version
 }
 
 func LastVersion() (string, error) {
@@ -87,20 +71,16 @@ func DownloadFile(saveAs string) error {
 	return nil
 }
 
-func GetBrowser(userAgent string) (browser *Browser, ok bool) {
-	if !initialized {
-		return
-	}
-
+func (browscap *BrowsCap) GetBrowser(userAgent string) (browser *Browser, ok bool) {
 	agent := mapToBytes(unicode.ToLower, userAgent)
 	defer bytesPool.Put(agent)
 
-	name := dict.tree.Find(agent)
+	name := browscap.dict.tree.Find(agent)
 	if name == "" {
 		return
 	}
 
-	browser = dict.getBrowser(name)
+	browser = browscap.dict.getBrowser(name)
 	if browser != nil {
 		ok = true
 	}

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -82,6 +82,14 @@ func TestGetBrowserIssues(t *testing.T) {
 	} else if browser.DeviceType != "Tablet" {
 		t.Errorf("Expected tablet %q", browser.DeviceType)
 	}
+
+	// Trailing wildcard handling bug
+	ua = "ApacheBench/"
+	if browser, ok := GetBrowser(ua); !ok {
+		t.Error("Browser not found")
+	} else if browser.Browser != "Apache Bench" {
+		t.Errorf("Expected Apache Bench %q", browser.Browser)
+	}
 }
 
 func TestLastVersion(t *testing.T) {

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -93,6 +93,14 @@ func TestGetBrowserIssues(t *testing.T) {
 	} else if browser.Browser != "Apache Bench" {
 		t.Errorf("Expected Apache Bench %q", browser.Browser)
 	}
+
+	// Rule sorting issue (score by rule lenght not by line number)
+	ua = "Mozilla/5.0 (Linux; Android 7.1.1; SM-T377T Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36"
+	if browser, ok := GetBrowser(ua); !ok {
+		t.Error("Browser not found")
+	} else if browser.DeviceType != "Tablet" {
+		t.Errorf("Expected Tablet %q", browser.DeviceType)
+	}
 }
 
 func TestLastVersion(t *testing.T) {

--- a/browscap_test.go
+++ b/browscap_test.go
@@ -75,7 +75,15 @@ func TestGetBrowserIssues(t *testing.T) {
 	} else if browser.DeviceType != "Tablet" {
 		t.Errorf("Expected tablet %q", browser.DeviceType)
 	}
+
+	ua = "Mozilla/5.0 (Linux; U; Android 4.1.2; en-gb; GT-N8010 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
+	if browser, ok := GetBrowser(ua); !ok {
+		t.Error("Browser not found")
+	} else if browser.DeviceType != "Tablet" {
+		t.Errorf("Expected tablet %q", browser.DeviceType)
+	}
 }
+
 func TestLastVersion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/browser.go
+++ b/browser.go
@@ -30,9 +30,10 @@ type Browser struct {
 
 	// Mobile Phone, Mobile Device, Tablet, Desktop, TV Device, Console,
 	// FonePad, Ebook Reader, Car Entertainment System or unknown
-	DeviceType  string
-	DeviceName  string
-	DeviceBrand string
+	DeviceType     string
+	DeviceName     string
+	DeviceCodeName string
+	DeviceBrand    string
 
 	Crawler string
 
@@ -123,6 +124,8 @@ func (browser *Browser) setValue(key, item string) {
 	} else if key == "Device_Type" {
 		browser.DeviceType = item
 	} else if key == "Device_Code_Name" {
+		browser.DeviceCodeName = item
+	} else if key == "Device_Name" {
 		browser.DeviceName = item
 	} else if key == "Device_Brand_Name" {
 		browser.DeviceBrand = item
@@ -169,6 +172,9 @@ func extractBrowser(data map[string]string) *Browser {
 		browser.DeviceType = item
 	}
 	if item, ok := data["Device_Code_Name"]; ok {
+		browser.DeviceCodeName = item
+	}
+	if item, ok := data["Device_Name"]; ok {
 		browser.DeviceName = item
 	}
 	if item, ok := data["Device_Brand_Name"]; ok {
@@ -207,11 +213,11 @@ func (browser *Browser) IsAndroid() bool {
 }
 
 func (browser *Browser) IsIPhone() bool {
-	return browser.Platform == "iOS" && browser.DeviceName == "iPhone"
+	return browser.Platform == "iOS" && browser.DeviceCodeName == "iPhone"
 }
 
 func (browser *Browser) IsIPad() bool {
-	return browser.Platform == "iOS" && browser.DeviceName == "iPad"
+	return browser.Platform == "iOS" && browser.DeviceCodeName == "iPad"
 }
 
 func (browser *Browser) IsWinPhone() bool {

--- a/loader.go
+++ b/loader.go
@@ -58,6 +58,9 @@ func loadFromIniFile(path string) (*dictionary, error) {
 
 		// Parse Value
 		valb := bytes.TrimSpace(line[kvSplit+1:])
+		if len(valb) == 0 {
+			continue
+		}
 		if valb[0] == '"' || valb[0] == '\'' {
 			valb = valb[1 : len(valb)-1]
 		}

--- a/loader.go
+++ b/loader.go
@@ -78,7 +78,9 @@ func loadFromIniFile(path string) (*dictionary, error) {
 		if _, ok := dict.browsers[sectionName]; !ok {
 			dict.tree.Add(sectionName, lineNum)
 
-			browser := &Browser{}
+			browser := &Browser{
+				Section: sectionName,
+			}
 			browser.setValue(key, val)
 			dict.browsers[sectionName] = browser
 		} else {

--- a/loader.go
+++ b/loader.go
@@ -6,6 +6,7 @@ package browscap_go
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"os"
 )
 
@@ -20,20 +21,25 @@ var (
 	versionKey     = "Version"
 )
 
-func loadFromIniFile(path string) (*dictionary, error) {
+func NewBrowsCapFromFile(path string) (*BrowsCap, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
+	return NewBrowsCapFromReader(file)
+}
+
+func NewBrowsCapFromReader(reader io.Reader) (*BrowsCap, error) {
 	dict := newDictionary()
+	var version string
 
 	sectionName := ""
 
 	lineNum := 0
 
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 
@@ -97,5 +103,5 @@ func loadFromIniFile(path string) (*dictionary, error) {
 		return nil, err
 	}
 
-	return dict, nil
+	return &BrowsCap{dict, version}, nil
 }

--- a/re0.go
+++ b/re0.go
@@ -72,16 +72,16 @@ func (t *Token) MatchOne(r []byte) (bool, []byte) {
 
 	if t.multi {
 		ind := bytes.Index(r, t.match)
-		if ind == -1 {
-			return false, nil
+		if ind >= 0 {
+			return true, r[ind+n:]
 		}
-		return true, r[ind+n:]
+	} else {
+		if bytes.Equal(r[:n], t.match) {
+			return true, r[n:]
+		}
 	}
 
-	if !bytes.Equal(r[:n], t.match) {
-		return false, nil
-	}
-	return true, r[n:]
+	return false, nil
 }
 
 type parserState struct {
@@ -145,7 +145,7 @@ func (ps *parserState) last() {
 
 func CompileExpression(s []byte) Expression {
 	state := &parserState{
-		exp:      Expression{},
+		exp:      make(Expression, 0, 8),
 		lastMode: -1,
 	}
 	reader := bytes.NewReader(s)

--- a/tree.go
+++ b/tree.go
@@ -98,19 +98,21 @@ func (n *node) findBest(s []byte, minScore int, x int) (res string, maxScore int
 			return "", n.topScore
 		}
 
-		if len(s) == 0 {
+		if len(s) == 0 && len(n.nodesFuzzy) == 0 {
 			return n.name, n.topScore
 		}
 	}
 
-	for _, nd := range n.nodesPure[s[0]] {
-		if nd.topScore > minScore {
-			break
-		}
-		r, ms := nd.findBest(s, minScore, x+1)
-		if r != "" && ms < minScore {
-			res = r
-			minScore = ms
+	if len(s) > 0 {
+		for _, nd := range n.nodesPure[s[0]] {
+			if nd.topScore > minScore {
+				break
+			}
+			r, ms := nd.findBest(s, minScore, x+1)
+			if r != "" && ms < minScore {
+				res = r
+				minScore = ms
+			}
 		}
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -95,6 +95,7 @@ func (n *node) addChild(a *node) {
 		shard := a.token.Shard()
 		n.nodesPure[shard] = append(n.nodesPure[shard], a)
 	}
+	n.sorted = false
 }
 
 func (n *node) findBest(s []byte, minScore int, x int) (res string, maxScore int) {

--- a/tree.go
+++ b/tree.go
@@ -72,30 +72,22 @@ type node struct {
 
 	nodesPure  map[byte]nodes
 	nodesFuzzy nodes
-	sorted     bool
 
 	topScore int
-}
-
-func (n *node) sortChildren() {
-	sort.Sort(n.nodesFuzzy)
-	for _, ch := range n.nodesPure {
-		sort.Sort(ch)
-	}
-	n.sorted = true
 }
 
 func (n *node) addChild(a *node) {
 	if a.token.Fuzzy() {
 		n.nodesFuzzy = append(n.nodesFuzzy, a)
+		sort.Sort(n.nodesFuzzy)
 	} else {
 		if n.nodesPure == nil {
 			n.nodesPure = map[byte]nodes{}
 		}
 		shard := a.token.Shard()
 		n.nodesPure[shard] = append(n.nodesPure[shard], a)
+		sort.Sort(n.nodesPure[shard])
 	}
-	n.sorted = false
 }
 
 func (n *node) findBest(s []byte, minScore int, x int) (res string, maxScore int) {
@@ -109,10 +101,6 @@ func (n *node) findBest(s []byte, minScore int, x int) (res string, maxScore int
 		if len(s) == 0 {
 			return n.name, n.topScore
 		}
-	}
-
-	if !n.sorted {
-		n.sortChildren()
 	}
 
 	for _, nd := range n.nodesPure[s[0]] {


### PR DESCRIPTION
This pull request fixes https://github.com/digitalcrab/browscap_go/issues/6 and fixes https://github.com/digitalcrab/browscap_go/issues/8

Unfortunately I didn't notice the issues earlier because it wasn't an issue with older versions of browscap data. I used to score lines by length but switched to line number because some crawlers weren't detected correctly in old versions of data if I did it with the rule length so I just assumed that the order of lines is the correct logic.

Plus some minor optimizations and fixes.

