### PR TITLE
Add an InitBrowsCapFromBuffer() function.

### DIFF
--- a/browscap.go
+++ b/browscap.go
@@ -4,6 +4,7 @@
 package browscap_go
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -31,10 +32,24 @@ func InitBrowsCap(path string, force bool) error {
 	if initialized && !force {
 		return nil
 	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("browscap: An error occurred while reading %s, %v ", path, err)
+	}
+	defer file.Close()
+
+	return InitBrowsCapFromBuffer(bufio.NewReader(file), force)
+}
+
+func InitBrowsCapFromBuffer(buf *bufio.Reader, force bool) error {
+	if initialized && !force {
+		return nil
+	}
 	var err error
 
 	// Load ini file
-	if dict, err = loadFromIniFile(path); err != nil {
+	if dict, err = loadFromIniFileBuffer(buf); err != nil {
 		return fmt.Errorf("browscap: An error occurred while reading file, %v ", err)
 	}
 

--- a/loader.go
+++ b/loader.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"os"
 )
 
 var (
@@ -25,16 +24,9 @@ var (
 	versionKey     = "Version"
 )
 
-func loadFromIniFile(path string) (*dictionary, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
+func loadFromIniFileBuffer(buf *bufio.Reader) (*dictionary, error) {
 	dict := newDictionary()
 
-	buf := bufio.NewReader(file)
 	sectionName := ""
 
 	lineNum := 0


### PR DESCRIPTION
Sometimes you might want to give browscap a file that doesn't live on
the filesystem (say, for tests, or because you want to give it a
compressed file).  This commit lets you do that by passing in any
buffered-file object, rather than requiring a filename.