### PR TITLE
Prefer `Device_Name` to `Device_Code_Name` for browser.DeviceName.

### DIFF
--- a/browscap_test.go
+++ b/browscap_test.go
@@ -60,6 +60,7 @@ func TestGetBrowserYandex(t *testing.T) {
 		t.Errorf("Expected false but got %t", browser.IsCrawler())
 	}
 }
+
 func TestGetBrowser360Spider(t *testing.T) {
 	if browser, ok := GetBrowser("360Spider"); !ok {
 		t.Error("Browser not found")
@@ -79,6 +80,16 @@ func TestGetBrowserIssues(t *testing.T) {
 		t.Errorf("Expected tablet %q", browser.DeviceType)
 	}
 }
+
+func TestGetBrowserDeviceName(t *testing.T) {
+	ua := "Mozilla/5.0 (Linux; Android 4.4.2; SM-T230 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36"
+	if browser, ok := GetBrowser(ua); !ok {
+		t.Error("Browser not found")
+	} else if browser.DeviceName != "Galaxy Tab 4 7.0" {
+		t.Errorf("Expected tablet %q", browser.DeviceName)
+	}
+}
+
 func TestLastVersion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/browser.go
+++ b/browser.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Browser struct {
-	parent  string //name of the parent
+	parent  string // name of the parent
 	built   bool   // has complete data from parents
 	buildMu sync.Mutex
 
@@ -121,8 +121,13 @@ func (browser *Browser) setValue(key, item string) {
 		browser.RenderingEngineVersion = item
 	} else if key == "Device_Type" {
 		browser.DeviceType = item
-	} else if key == "Device_Code_Name" {
+	} else if key == "Device_Name" {
 		browser.DeviceName = item
+	} else if key == "Device_Code_Name" {
+		// Prefer Device_Name to Device_Code_Name.
+		if browser.DeviceName == "" {
+			browser.DeviceName = item
+		}
 	} else if key == "Device_Brand_Name" {
 		browser.DeviceBrand = item
 	}


### PR DESCRIPTION
Before, it was only looking at Device_Code_Name.  But Device_Name is a
separate field that sometimes has a different value than
Device_Code_Name.  This change makes it so we prefer the former to the
latter.

This is an API-breaking change, but I think it's the right thing to do
based on my (admittedly scant) understanding of these ini fields.